### PR TITLE
Script Speed - Assessment Taking Too Long

### DIFF
--- a/Install-Prerequisites.ps1
+++ b/Install-Prerequisites.ps1
@@ -52,6 +52,7 @@ $requiredModules = @(
     @{ Name = 'Microsoft.Graph.Identity.DirectoryManagement'; MinVersion = '2.0.0' }
     @{ Name = 'Microsoft.Graph.Identity.SignIns'; MinVersion = '2.0.0' }
     @{ Name = 'Microsoft.Graph.Groups'; MinVersion = '2.0.0' }
+    @{ Name = 'Microsoft.Graph.Reports'; MinVersion = '2.0.0' }
     @{ Name = 'ExchangeOnlineManagement'; MinVersion = '3.0.0' }
 )
 

--- a/modules/Security/Test-ConditionalAccess.ps1
+++ b/modules/Security/Test-ConditionalAccess.ps1
@@ -24,14 +24,22 @@ function Test-ConditionalAccess {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]
-        [PSCustomObject]$Config
+        [PSCustomObject]$Config,
+
+        [Parameter(Mandatory = $false)]
+        [array]$ConditionalAccessPolicies
     )
 
     try {
         Write-Verbose "Analyzing Conditional Access policies..."
 
         # Get all Conditional Access policies
-        $caPolicies = Get-MgIdentityConditionalAccessPolicy -All
+        $caPolicies = if ($ConditionalAccessPolicies) {
+            $ConditionalAccessPolicies
+        }
+        else {
+            Get-MgIdentityConditionalAccessPolicy -All
+        }
 
         $totalPolicies = $caPolicies.Count
         $enabledPolicies = ($caPolicies | Where-Object { $_.State -eq 'enabled' }).Count

--- a/modules/Security/Test-LegacyAuth.ps1
+++ b/modules/Security/Test-LegacyAuth.ps1
@@ -24,14 +24,22 @@ function Test-LegacyAuth {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]
-        [PSCustomObject]$Config
+        [PSCustomObject]$Config,
+
+        [Parameter(Mandatory = $false)]
+        [array]$ConditionalAccessPolicies
     )
 
     try {
         Write-Verbose "Analyzing legacy authentication configuration..."
 
         # Check Conditional Access policies for legacy auth blocking
-        $caPolicies = Get-MgIdentityConditionalAccessPolicy -All
+        $caPolicies = if ($ConditionalAccessPolicies) {
+            $ConditionalAccessPolicies
+        }
+        else {
+            Get-MgIdentityConditionalAccessPolicy -All
+        }
 
         $legacyAuthBlockPolicies = $caPolicies | Where-Object {
             $_.State -eq 'enabled' -and (


### PR DESCRIPTION
Fixes #19

Added per-module timing and shared data caching in the orchestrator, preloading Conditional Access policies and authentication registration details once and reusing them across modules; made Exchange connection conditional on Exchange runs.
Refactored MFA and privileged-account checks to consume the cached auth registration data (no per-user auth-method calls or sleeps) and log whether cached or live data was used; CA/LegacyAuth modules now accept cached policies.
Introduced a helper to call whatever Graph registration detail cmdlet is available and updated prerequisites to install Microsoft.Graph.Reports, ensuring the cache step succeeds.